### PR TITLE
circumcircle fix

### DIFF
--- a/voronoi/voronoi/voronoi.py
+++ b/voronoi/voronoi/voronoi.py
@@ -24,8 +24,13 @@ def circumcircle(P1,P2,P3):
         center_x = 0.5*(P2[0] + P3[0])
         center_y = 0.5*(P1[1] + P2[1])
     else:
-        aSlope = delta_a[1]/delta_a[0]
-        bSlope = delta_b[1]/delta_b[0]
+        if delta_a[0] == 0: aSlope = delta_a[1]/epsilon
+        elif delta_a[1] == 0: aSlope = epsilon
+        else: aSlope = delta_a[1]/delta_a[0]
+        
+        if delta_b[0] == 0: bSlope = delta_b[1]/epsilon
+        else: bSlope = delta_b[1]/delta_b[0]
+        
         if np.abs(aSlope-bSlope) <= epsilon:
             return None
         center_x= (aSlope*bSlope*(P1[1] - P3[1]) + bSlope*(P1[0] + P2 [0]) \


### PR DESCRIPTION
Dear Friends,
I am very grateful to you for putting this script up here for everybody to use.

I used it with geographical locations to display the Voronoi tessellation on a map. I encountered trouble with  the circumcircle function in the special case when two of the three points would be on the X or Y axis. For example:
p1 = (10, 15)
p2 = (13, 15) 
p3 = (11, 10)
would not generate a polygon, because a division by 0 would happen in the algorithm.

The small adjustment I made resolves this issue. Please see if you can add it to the main branch. Perhaps you can come up with a more elegant solution.

Best wishes
Michal
